### PR TITLE
Implemented token `burn` function and added corresponding test cases

### DIFF
--- a/contracts/Uni.sol
+++ b/contracts/Uni.sol
@@ -115,11 +115,10 @@ contract Uni {
      * @param rawAmount The number of tokens to be minted
      */
     function burn(uint rawAmount) external {
-        uint96 amount = safe96(rawAmount, "Vexchange::approve: amount exceeds 96 bits");
-        require(amount <= balances[msg.sender], "Vexchange::burn token balance is less than the burn amount");
+        uint96 amount = safe96(rawAmount, "Vexchange::burn amount exceeds 96 bits");
 
         balances[msg.sender] = sub96(balances[msg.sender], amount, "Vexchange::burn new balance underflows");
-        totalSupply = safe96(SafeMath.sub(totalSupply, amount), "Vexchange::burn new supply exceeds 96 bits");
+        totalSupply = SafeMath.sub(totalSupply, amount);
 
         emit Transfer(msg.sender, address(0), amount);
 

--- a/contracts/Uni.sol
+++ b/contracts/Uni.sol
@@ -111,6 +111,23 @@ contract Uni {
     }
 
     /**
+     * @notice Burns tokens
+     * @param rawAmount The number of tokens to be minted
+     */
+    function burn(uint rawAmount) external {
+        uint96 amount = safe96(rawAmount, "Vexchange::approve: amount exceeds 96 bits");
+        require(amount <= balances[msg.sender], "Vexchange::burn token balance is less than the burn amount");
+
+        balances[msg.sender] = sub96(balances[msg.sender], amount, "Vexchange::burn new balance underflows");
+        totalSupply = safe96(SafeMath.sub(totalSupply, amount), "Vexchange::burn new supply exceeds 96 bits");
+
+        emit Transfer(msg.sender, address(0), amount);
+
+        // move the votes to the zero address
+        _moveDelegates(delegates[msg.sender], address(0), amount);
+    }
+
+    /**
      * @notice Get the number of tokens `spender` is approved to spend on behalf of `account`
      * @param account The address of the account holding the funds
      * @param spender The address of the account spending the funds

--- a/contracts/Uni.sol
+++ b/contracts/Uni.sol
@@ -112,7 +112,7 @@ contract Uni {
 
     /**
      * @notice Burns tokens
-     * @param rawAmount The number of tokens to be minted
+     * @param rawAmount The number of tokens to be burnt
      */
     function burn(uint rawAmount) external {
         uint96 amount = safe96(rawAmount, "Vexchange::burn amount exceeds 96 bits");

--- a/test/Uni.spec.ts
+++ b/test/Uni.spec.ts
@@ -109,4 +109,29 @@ describe('Uni', () => {
     await uni.mint(wallet.address, amount)
     expect(await uni.balanceOf(wallet.address)).to.be.eq(supply.add(amount))
   })
+
+  it('burn', async () => {
+    const uni = await deployContract(wallet, Uni, [wallet.address, wallet.address])
+    let supply = await uni.totalSupply();
+    
+    // Cannot burn more than uint96 limit 
+    await expect(uni.burn("79228162514264337593543950337")).to.be.revertedWith("Vexchange::approve: amount exceeds 96 bits");
+
+    // Cannot burn more than what the wallet owns
+    await expect(uni.burn(supply + 1)).to.be.revertedWith("Vexchange::burn token balance is less than the burn amount");
+
+    // Can burn a given amount 
+    const amountToBurn = expandTo18Decimals(1000);
+    await uni.burn(amountToBurn);
+    expect(await uni.balanceOf(wallet.address)).to.eq(supply.sub(amountToBurn));
+    expect(await uni.totalSupply()).to.eq(supply.sub(amountToBurn));
+
+    supply = await uni.totalSupply();
+
+    // Burn 0 tokens
+    const zeroAmount = 0;
+    await uni.burn(zeroAmount);
+    expect(await uni.balanceOf(wallet.address)).to.eq(supply);
+    expect(await uni.totalSupply()).to.eq(supply);
+  });
 })

--- a/test/Uni.spec.ts
+++ b/test/Uni.spec.ts
@@ -115,10 +115,10 @@ describe('Uni', () => {
     let supply = await uni.totalSupply();
     
     // Cannot burn more than uint96 limit 
-    await expect(uni.burn("79228162514264337593543950337")).to.be.revertedWith("Vexchange::approve: amount exceeds 96 bits");
+    await expect(uni.burn("79228162514264337593543950337")).to.be.revertedWith("Vexchange::burn amount exceeds 96 bits");
 
     // Cannot burn more than what the wallet owns
-    await expect(uni.burn(supply + 1)).to.be.revertedWith("Vexchange::burn token balance is less than the burn amount");
+    await expect(uni.burn(supply + 1)).to.be.revertedWith("Vexchange::burn new balance underflows");
 
     // Can burn a given amount 
     const amountToBurn = expandTo18Decimals(1000);


### PR DESCRIPTION
1. In the two implementations I found, PCS doesn't do `_moveDelegates` while ACS does. 

See:

CAKE token's[ implementation](https://bscscan.com/address/0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82#code)
ACS token's [implementation](https://bscscan.com/address/0x7679381507af0c8de64586a458161aa58d3a4fc3?a=0xbc8ab4cdc40990f09c1fd6e0feb6b3cb1f940744#code)

I think that calling `_moveDelegates` will result in a more accurate set of records in the `checkpoints` structure. I'm not sure what implications of not having the checkpoints in perfect accuracy because I haven't seen code that reads from it. Still, I think it is good to maintain the `checkpoints` map in a more accurate condition.


2.  In the above examples their `burn` functions are `internal`, and are supposedly called by some privileged accounts, so it takes an address to burn from. But in our construct we should make them `external`, just like the `mint` function does, so we don't need to explicitly take in an address, but instead just use `msg.sender` 